### PR TITLE
Prevent to print #<unspecified>

### DIFF
--- a/src/guile-jupyter-kernel.scm
+++ b/src/guile-jupyter-kernel.scm
@@ -111,6 +111,10 @@
   (send socket uuid (header- "kernel_info_reply") parent-header metadata (scm->json-string KERNEL-INFO)))
 
 (define (reply-execute-request socket uuid header- parent-header metadata content)
+  (define (proper-print x)
+    (if (unspecified? x)
+        ""
+        x))
   (let ((code              (string-append    "(begin " (hash-ref content "code") ")")) ;; make one s-expression from possible list
 	(silent            (hash-ref content "silent"))
 	(store-history     (hash-ref content "store_history"))
@@ -130,7 +134,7 @@
 	     ;; evaluate code
 	     (lambda ()
 	       (set! result (with-output-to-string
-			      (lambda () (write (eval (with-input-from-string code read) (interaction-environment)))))))
+			      (lambda () (proper-print (eval-string code (interaction-environment)))))))
 	     ;; get error message in case of an exception
 	     (lambda (key . parameters)
 	       (set! err #t) 


### PR DESCRIPTION
If we try (display (+ 1 2)), then it prints 2#\<unspecified\>, this patch prevents the unspecified symbol.