### PR TITLE
Use Guile-Gcrypt instead of 'openssl' to compute HMACs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ $ cd `guile -c "(display (%global-site-dir))"`
 $ wget https://raw.githubusercontent.com/jerry40/guile-simple-zmq/master/src/simple-zmq.scm
 ```
 
+Last, [Guile-Gcrypt](https://notabug.org/cwebber/guile-gcrypt) is needed
+to compute hash-based message authentication codes (HMACs) while
+communicating with Jupyter:
+```
+$ wget https://notabug.org/cwebber/guile-gcrypt/archive/v0.1.0.tar.gz
+$ tar xvf v0.1.0.tar.gz
+$ cd guile-gcrypt-0.1.0
+$ autoreconf -vfi
+$ ./configure --prefix=<guile-prefix>
+$ make
+$ sudo make install
+```
+
 ## Kernel setup
 According to the [article](http://jupyter-client.readthedocs.io/en/stable/kernels.html), the kernel can be placed into different loactions:
 

--- a/src/guile-jupyter-kernel.scm
+++ b/src/guile-jupyter-kernel.scm
@@ -1,10 +1,10 @@
 (use-modules (simple-zmq)
 	     (json)
+             (hmac)
 	     (srfi srfi-1)
              (srfi srfi-13))
 
 (include "tools.scm")
-(include "hmac.scm")
 
 (define DELIM "<IDS|MSG>")
 

--- a/src/hmac.scm
+++ b/src/hmac.scm
@@ -1,19 +1,12 @@
-(use-modules (ice-9 rdelim)
-	     (ice-9 popen))
+(define-module (hmac)
+  #:use-module (gcrypt hmac)
+  #:use-module (gcrypt base16)
+  #:use-module (rnrs bytevectors)
+  #:export (get-signature))
 
 (define (get-signature key str)
-  (let* ((p2c (pipe))	 
-	 (read-pipe  (car p2c))
-	 (write-pipe (cdr p2c))
-	 (port       (with-input-from-port read-pipe
-		       (lambda ()
-			 (open-input-pipe (string-append "openssl dgst -sha256 -hmac " key))))))
-    (display str write-pipe)    
-    (close-port write-pipe)
-    (let ((result (read-line port)))
-      (close-port read-pipe)
-      (close-pipe port)
-      (substring result 9))))
-	 
-
-
+  "Return a hexadecimal string containing the SHA256 HMAC of STR, a string,
+with KEY, another string."
+  (bytevector->base16-string
+   (sign-data key (string->utf8 str)
+              #:algorithm 'sha256)))


### PR DESCRIPTION
Hello!

This change replaces the dependency on OpenSSL with a dependency on [Guile-Gcrypt](https://notabug.org/cwebber/guile-gcrypt).  It also makes `hmac.scm` a proper module (we should consider doing this for `tools.scm` as well.)

Thanks for this nice kernel!

Ludo'.